### PR TITLE
updated to be consistent with new github rules

### DIFF
--- a/authnz-0.5.1-1.rockspec
+++ b/authnz-0.5.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "authnz"
 version = "0.5.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-authnz.git",
+    url = "git+https://github.com/mah0x211/lua-authnz.git",
     tag = "v0.5.1"
 }
 description = {

--- a/base64mix-1.0.0-1.rockspec
+++ b/base64mix-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "base64mix"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-base64mix.git",
+    url = "git+https://github.com/mah0x211/lua-base64mix.git",
     tag = 'v1.0.0'
 }
 description = {

--- a/bitvec-1.0.0-1.rockspec
+++ b/bitvec-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "bitvec"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-bitvec.git",
+    url = "git+https://github.com/mah0x211/lua-bitvec.git",
     tag = 'v1.0.0'
 }
 description = {

--- a/bitvec-2.0.0-1.rockspec
+++ b/bitvec-2.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "bitvec"
 version = "2.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-bitvec.git",
+    url = "git+https://github.com/mah0x211/lua-bitvec.git",
     tag = 'v2.0.0'
 }
 description = {

--- a/blake2-1.0.1-1.rockspec
+++ b/blake2-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "blake2"
 version = "1.0.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-blake2.git",
+    url = "git+https://github.com/mah0x211/lua-blake2.git",
     tag = "v1.0.1"
 }
 description = {

--- a/buffer-scm-1.rockspec
+++ b/buffer-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "buffer"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-buffer.git"
+    url = "git+https://github.com/mah0x211/lua-buffer.git"
 }
 description = {
     summary = "buffer module",

--- a/cache-1.0.1-1.rockspec
+++ b/cache-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache"
 version = "1.0.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache.git",
+    url = "git+https://github.com/mah0x211/lua-cache.git",
     tag = "v1.0.1"
 }
 description = {

--- a/cache-1.1.0-1.rockspec
+++ b/cache-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache.git",
+    url = "git+https://github.com/mah0x211/lua-cache.git",
     tag = "v1.1.0"
 }
 description = {

--- a/cache-1.2.0-1.rockspec
+++ b/cache-1.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache"
 version = "1.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache.git",
+    url = "git+https://github.com/mah0x211/lua-cache.git",
     tag = "v1.2.0"
 }
 description = {

--- a/cache-etcd-1.0.1-1.rockspec
+++ b/cache-etcd-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-etcd"
 version = "1.0.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-etcd.git",
+    url = "git+https://github.com/mah0x211/lua-cache-etcd.git",
     tag = "v1.0.1"
 }
 description = {

--- a/cache-resty-dict-1.1.0-1.rockspec
+++ b/cache-resty-dict-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-resty-dict"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-resty-dict.git",
+    url = "git+https://github.com/mah0x211/lua-cache-resty-dict.git",
     tag = "v1.1.0"
 }
 description = {

--- a/cache-resty-dict-1.1.1-1.rockspec
+++ b/cache-resty-dict-1.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-resty-dict"
 version = "1.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-resty-dict.git",
+    url = "git+https://github.com/mah0x211/lua-cache-resty-dict.git",
     tag = "v1.1.1"
 }
 description = {

--- a/cache-resty-memcached-0.1.0-1.rockspec
+++ b/cache-resty-memcached-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-resty-memcached"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-resty-memcached.git",
+    url = "git+https://github.com/mah0x211/lua-cache-resty-memcached.git",
     tag = "v0.1.0"
 }
 description = {

--- a/cache-resty-memcached-0.1.1-1.rockspec
+++ b/cache-resty-memcached-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-resty-memcached"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-resty-memcached.git",
+    url = "git+https://github.com/mah0x211/lua-cache-resty-memcached.git",
     tag = "v0.1.1"
 }
 description = {

--- a/cache-resty-memcached-0.1.2-1.rockspec
+++ b/cache-resty-memcached-0.1.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-resty-memcached"
 version = "0.1.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-resty-memcached.git",
+    url = "git+https://github.com/mah0x211/lua-cache-resty-memcached.git",
     tag = "v0.1.2"
 }
 description = {

--- a/cache-resty-redis-1.1.1-1.rockspec
+++ b/cache-resty-redis-1.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-resty-redis"
 version = "1.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-resty-redis.git",
+    url = "git+https://github.com/mah0x211/lua-cache-resty-redis.git",
     tag = "v1.1.1"
 }
 description = {

--- a/cache-resty-redis-1.2.0-1.rockspec
+++ b/cache-resty-redis-1.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-resty-redis"
 version = "1.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-resty-redis.git",
+    url = "git+https://github.com/mah0x211/lua-cache-resty-redis.git",
     tag = "v1.2.0"
 }
 description = {

--- a/cache-resty-redis-1.2.1-1.rockspec
+++ b/cache-resty-redis-1.2.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "cache-resty-redis"
 version = "1.2.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cache-resty-redis.git",
+    url = "git+https://github.com/mah0x211/lua-cache-resty-redis.git",
     tag = "v1.2.1"
 }
 description = {

--- a/codec-1.1.0-1.rockspec
+++ b/codec-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "codec"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-codec.git",
+    url = "git+https://github.com/mah0x211/lua-codec.git",
     tag = "v1.1.0"
 }
 description = {

--- a/coevent-scm-1.rockspec
+++ b/coevent-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "coevent"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-coevent.git"
+    url = "git+https://github.com/mah0x211/lua-coevent.git"
 }
 description = {
     summary = "kqueue/epoll event module",

--- a/cookie-1.1.3-1.rockspec
+++ b/cookie-1.1.3-1.rockspec
@@ -1,7 +1,7 @@
 package = "cookie"
 version = "1.1.3-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cookie.git",
+    url = "git+https://github.com/mah0x211/lua-cookie.git",
     tag = "v1.1.3"
 }
 description = {

--- a/cookie-1.1.4-1.rockspec
+++ b/cookie-1.1.4-1.rockspec
@@ -1,7 +1,7 @@
 package = "cookie"
 version = "1.1.4-1"
 source = {
-    url = "git://github.com/mah0x211/lua-cookie.git",
+    url = "git+https://github.com/mah0x211/lua-cookie.git",
     tag = "v1.1.4"
 }
 description = {

--- a/ddl-1.1.1-1.rockspec
+++ b/ddl-1.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "ddl"
 version = "1.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-ddl.git",
+    url = "git+https://github.com/mah0x211/lua-ddl.git",
     tag = "v1.1.1"
 }
 description = {

--- a/deq-0.1.0-1.rockspec
+++ b/deq-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "deq"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-deq.git",
+    url = "git+https://github.com/mah0x211/lua-deq.git",
     tag = "v0.1.0"
 }
 description = {

--- a/deq-0.2.0-1.rockspec
+++ b/deq-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "deq"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-deq.git",
+    url = "git+https://github.com/mah0x211/lua-deq.git",
     tag = "v0.2.0"
 }
 description = {

--- a/digest-1.0.0-1.rockspec
+++ b/digest-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "digest"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-digest.git",
+    url = "git+https://github.com/mah0x211/lua-digest.git",
     tag = "v1.0.0"
 }
 description = {

--- a/digitalocean-0.2.1-1.rockspec
+++ b/digitalocean-0.2.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "digitalocean"
 version = "0.2.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-digitalocean.git",
+    url = "git+https://github.com/mah0x211/lua-digitalocean.git",
     tag = "v0.2.1"
 }
 description = {

--- a/dropbox-0.1.1-1.rockspec
+++ b/dropbox-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "dropbox"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-dropbox.git",
+    url = "git+https://github.com/mah0x211/lua-dropbox.git",
     tag = "v0.1.1"
 }
 description = {

--- a/dump-0.1.0-1.rockspec
+++ b/dump-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "dump"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-dump.git",
+    url = "git+https://github.com/mah0x211/lua-dump.git",
     tag = "v0.1.0"
 }
 description = {

--- a/dump-0.1.1-1.rockspec
+++ b/dump-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "dump"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-dump.git",
+    url = "git+https://github.com/mah0x211/lua-dump.git",
     tag = "v0.1.1"
 }
 description = {

--- a/etcd-0.12.0-1.rockspec
+++ b/etcd-0.12.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "etcd"
 version = "0.12.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-etcd.git",
+    url = "git+https://github.com/mah0x211/lua-etcd.git",
     tag = "v0.12.0"
 }
 description = {

--- a/etcd-resty-1.0.0-1.rockspec
+++ b/etcd-resty-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "etcd-resty"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-etcd-resty.git",
+    url = "git+https://github.com/mah0x211/lua-etcd-resty.git",
     tag = "v1.0.0"
 }
 description = {

--- a/fsrouter-scm-1.rockspec
+++ b/fsrouter-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "fsrouter"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-fsrouter.git"
+    url = "git+https://github.com/mah0x211/lua-fsrouter.git"
 }
 description = {
     summary = "filesystem based url router",

--- a/gcfn-0.1.0-1.rockspec
+++ b/gcfn-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "gcfn"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-gcfn.git",
+    url = "git+https://github.com/mah0x211/lua-gcfn.git",
     tag = "v0.1.0"
 }
 description = {

--- a/gcfn-0.2.0-1.rockspec
+++ b/gcfn-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "gcfn"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-gcfn.git",
+    url = "git+https://github.com/mah0x211/lua-gcfn.git",
     tag = "v0.2.0"
 }
 description = {

--- a/gcfn-0.2.1-1.rockspec
+++ b/gcfn-0.2.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "gcfn"
 version = "0.2.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-gcfn.git",
+    url = "git+https://github.com/mah0x211/lua-gcfn.git",
     tag = "v0.2.1"
 }
 description = {

--- a/geo-1.1.0-1.rockspec
+++ b/geo-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "geo"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-geo.git",
+    url = "git+https://github.com/mah0x211/lua-geo.git",
     tag = "v1.1.0"
 }
 description = {

--- a/getenv-0.1.0-1.rockspec
+++ b/getenv-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "getenv"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-getenv.git",
+    url = "git+https://github.com/mah0x211/lua-getenv.git",
     tag = 'v0.1.0'
 }
 description = {

--- a/halo-1.1.0-1.rockspec
+++ b/halo-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "halo"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-halo.git",
+    url = "git+https://github.com/mah0x211/lua-halo.git",
     tag = "v1.1.0"
 }
 description = {

--- a/halo-1.1.7-1.rockspec
+++ b/halo-1.1.7-1.rockspec
@@ -1,7 +1,7 @@
 package = "halo"
 version = "1.1.7-1"
 source = {
-    url = "git://github.com/mah0x211/lua-halo.git",
+    url = "git+https://github.com/mah0x211/lua-halo.git",
     tag = "v1.1.7"
 }
 description = {

--- a/halo-1.1.8-1.rockspec
+++ b/halo-1.1.8-1.rockspec
@@ -1,7 +1,7 @@
 package = "halo"
 version = "1.1.8-1"
 source = {
-    url = "git://github.com/mah0x211/lua-halo.git",
+    url = "git+https://github.com/mah0x211/lua-halo.git",
     tag = "v1.1.8"
 }
 description = {

--- a/halo-1.1.9-1.rockspec
+++ b/halo-1.1.9-1.rockspec
@@ -1,7 +1,7 @@
 package = "halo"
 version = "1.1.9-1"
 source = {
-    url = "git://github.com/mah0x211/lua-halo.git",
+    url = "git+https://github.com/mah0x211/lua-halo.git",
     tag = "v1.1.9"
 }
 description = {

--- a/hex-1.0.1-1.rockspec
+++ b/hex-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "hex"
 version = "1.0.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-hex.git",
+    url = "git+https://github.com/mah0x211/lua-hex.git",
     tag = "v1.0.1"
 }
 description = {

--- a/hex-1.0.2-1.rockspec
+++ b/hex-1.0.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "hex"
 version = "1.0.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-hex.git",
+    url = "git+https://github.com/mah0x211/lua-hex.git",
     tag = "v1.0.2"
 }
 description = {

--- a/httpcli-1.3.4-1.rockspec
+++ b/httpcli-1.3.4-1.rockspec
@@ -1,7 +1,7 @@
 package = "httpcli"
 version = "1.3.4-1"
 source = {
-    url = "git://github.com/mah0x211/lua-httpcli.git",
+    url = "git+https://github.com/mah0x211/lua-httpcli.git",
     tag = "v1.3.4"
 }
 description = {

--- a/httpcli-1.4.0-1.rockspec
+++ b/httpcli-1.4.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "httpcli"
 version = "1.4.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-httpcli.git",
+    url = "git+https://github.com/mah0x211/lua-httpcli.git",
     tag = "v1.4.0"
 }
 description = {

--- a/httpcli-1.4.1-1.rockspec
+++ b/httpcli-1.4.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "httpcli"
 version = "1.4.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-httpcli.git",
+    url = "git+https://github.com/mah0x211/lua-httpcli.git",
     tag = "v1.4.1"
 }
 description = {

--- a/httpcli-resty-1.2.2-1.rockspec
+++ b/httpcli-resty-1.2.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "httpcli-resty"
 version = "1.2.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-httpcli-resty.git",
+    url = "git+https://github.com/mah0x211/lua-httpcli-resty.git",
     tag = "v1.2.2"
 }
 description = {

--- a/httpconsts-1.0.1-1.rockspec
+++ b/httpconsts-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "httpconsts"
 version = "1.0.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-httpconsts.git",
+    url = "git+https://github.com/mah0x211/lua-httpconsts.git",
     tag = "v1.0.1"
 }
 description = {

--- a/idna-1.0.0-1.rockspec
+++ b/idna-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "idna"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-idna.git",
+    url = "git+https://github.com/mah0x211/lua-idna.git",
     tag = "v1.0.0"
 }
 description = {

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ Lua modules available from this location for use with <a href="http://www.luaroc
 <p><a name="authnz"></a><a href="#authnz" class="pkg"><b>authnz</b></a> - auth module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-authnz.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-authnz" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-authnz.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-authnz" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.5.1-1:&nbsp;<a href="authnz-0.5.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -81,7 +81,7 @@ Lua modules available from this location for use with <a href="http://www.luaroc
 <p><a name="base64mix"></a><a href="#base64mix" class="pkg"><b>base64mix</b></a> - base64 encode/decode module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-base64mix.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-base64mix" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-base64mix.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-base64mix" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.0-1:&nbsp;<a href="base64mix-1.0.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -99,7 +99,7 @@ Lua modules available from this location for use with <a href="http://www.luaroc
 <p><a name="blake2"></a><a href="#blake2" class="pkg"><b>blake2</b></a> - blake2 binding for lua<br/>
 </p><blockquote><p><br/>
 <p><b>External dependencies:</b> blake2</p>
-<font size="-1"><a href="git://github.com/mah0x211/lua-blake2.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-blake2" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-blake2.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-blake2" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.1-1:&nbsp;<a href="blake2-1.0.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -108,7 +108,7 @@ Lua modules available from this location for use with <a href="http://www.luaroc
 <p><a name="buffer"></a><a href="#buffer" class="pkg"><b>buffer</b></a> - buffer module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-buffer.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-buffer" target="_blank">project homepage</a> | License: MIT</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-buffer.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-buffer" target="_blank">project homepage</a> | License: MIT</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="buffer-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -117,7 +117,7 @@ scm-1:&nbsp;<a href="buffer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="cache"></a><a href="#cache" class="pkg"><b>cache</b></a> - pluggable cache storage module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-cache.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-cache.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.2.0-1:&nbsp;<a href="cache-1.2.0-1.rockspec">rockspec</a><br/>1.1.0-1:&nbsp;<a href="cache-1.1.0-1.rockspec">rockspec</a><br/>1.0.1-1:&nbsp;<a href="cache-1.0.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -126,7 +126,7 @@ scm-1:&nbsp;<a href="buffer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="cache-etcd"></a><a href="#cache-etcd" class="pkg"><b>cache-etcd</b></a> - etcd cache storage plugin for lua-cache module.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-cache-etcd.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache-etcd" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-cache-etcd.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache-etcd" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.1-1:&nbsp;<a href="cache-etcd-1.0.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -135,7 +135,7 @@ scm-1:&nbsp;<a href="buffer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="cache-resty-dict"></a><a href="#cache-resty-dict" class="pkg"><b>cache-resty-dict</b></a> - lua_shared_dict storage plugin for lua-cache module.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-cache-resty-dict.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache-resty-dict" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-cache-resty-dict.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache-resty-dict" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.1-1:&nbsp;<a href="cache-resty-dict-1.1.1-1.rockspec">rockspec</a><br/>1.1.0-1:&nbsp;<a href="cache-resty-dict-1.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -144,7 +144,7 @@ scm-1:&nbsp;<a href="buffer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="cache-resty-memcached"></a><a href="#cache-resty-memcached" class="pkg"><b>cache-resty-memcached</b></a> - resty-memcached cache storage plugin for lua-cache module.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-cache-resty-memcached.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache-resty-memcached" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-cache-resty-memcached.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache-resty-memcached" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.2-1:&nbsp;<a href="cache-resty-memcached-0.1.2-1.rockspec">rockspec</a><br/>0.1.1-1:&nbsp;<a href="cache-resty-memcached-0.1.1-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="cache-resty-memcached-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -153,7 +153,7 @@ scm-1:&nbsp;<a href="buffer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="cache-resty-redis"></a><a href="#cache-resty-redis" class="pkg"><b>cache-resty-redis</b></a> - resty-redis cache storage plugin for lua-cache module.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-cache-resty-redis.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache-resty-redis" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-cache-resty-redis.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cache-resty-redis" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.2.1-1:&nbsp;<a href="cache-resty-redis-1.2.1-1.rockspec">rockspec</a><br/>1.2.0-1:&nbsp;<a href="cache-resty-redis-1.2.0-1.rockspec">rockspec</a><br/>1.1.1-1:&nbsp;<a href="cache-resty-redis-1.1.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -162,7 +162,7 @@ scm-1:&nbsp;<a href="buffer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="codec"></a><a href="#codec" class="pkg"><b>codec</b></a> - encoding and decoding module collection.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-codec.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-codec" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-codec.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-codec" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.0-1:&nbsp;<a href="codec-1.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -171,7 +171,7 @@ scm-1:&nbsp;<a href="buffer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="coevent"></a><a href="#coevent" class="pkg"><b>coevent</b></a> - kqueue/epoll event module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-coevent.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-coevent" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-coevent.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-coevent" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -180,7 +180,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="cookie"></a><a href="#cookie" class="pkg"><b>cookie</b></a> - HTTP Cookie utility<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-cookie.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cookie" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-cookie.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-cookie" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.4-1:&nbsp;<a href="cookie-1.1.4-1.rockspec">rockspec</a><br/>1.1.3-1:&nbsp;<a href="cookie-1.1.3-1.rockspec">rockspec</a><br/></td></tr>
@@ -189,7 +189,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="ddl"></a><a href="#ddl" class="pkg"><b>ddl</b></a> - Lua as a Data Definition Language<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-ddl.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-ddl" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-ddl.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-ddl" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.1-1:&nbsp;<a href="ddl-1.1.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -207,7 +207,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="digest"></a><a href="#digest" class="pkg"><b>digest</b></a> - message digest module.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-digest.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-digest" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-digest.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-digest" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.0-1:&nbsp;<a href="digest-1.0.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -216,7 +216,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="digitalocean"></a><a href="#digitalocean" class="pkg"><b>digitalocean</b></a> - digitalocean client module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-digitalocean.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-digitalocean" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-digitalocean.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-digitalocean" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.2.1-1:&nbsp;<a href="digitalocean-0.2.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -225,7 +225,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="dropbox"></a><a href="#dropbox" class="pkg"><b>dropbox</b></a> - dropbox client module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-dropbox.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-dropbox" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-dropbox.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-dropbox" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.1-1:&nbsp;<a href="dropbox-0.1.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -234,7 +234,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="dump"></a><a href="#dump" class="pkg"><b>dump</b></a> - stringified lua data structures, suitable for both printing and loading as chunk<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-dump.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-dump" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-dump.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-dump" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.1-1:&nbsp;<a href="dump-0.1.1-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="dump-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -243,7 +243,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="etcd"></a><a href="#etcd" class="pkg"><b>etcd</b></a> - etcd client module.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-etcd.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-etcd" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-etcd.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-etcd" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.12.0-1:&nbsp;<a href="etcd-0.12.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -252,7 +252,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="etcd-resty"></a><a href="#etcd-resty" class="pkg"><b>etcd-resty</b></a> - etcd client module for OpenResty.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-etcd-resty.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-etcd-resty" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-etcd-resty.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-etcd-resty" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.0-1:&nbsp;<a href="etcd-resty-1.0.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -261,7 +261,7 @@ scm-1:&nbsp;<a href="coevent-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="fsrouter"></a><a href="#fsrouter" class="pkg"><b>fsrouter</b></a> - filesystem based url router<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-fsrouter.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-fsrouter" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-fsrouter.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-fsrouter" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -270,7 +270,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="gcfn"></a><a href="#gcfn" class="pkg"><b>gcfn</b></a> - create gc function for lua<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-gcfn.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-gcfn" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-gcfn.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-gcfn" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.2.1-1:&nbsp;<a href="gcfn-0.2.1-1.rockspec">rockspec</a><br/>0.2.0-1:&nbsp;<a href="gcfn-0.2.0-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="gcfn-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -279,7 +279,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="geo"></a><a href="#geo" class="pkg"><b>geo</b></a> - geo location util<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-geo.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-geo" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-geo.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-geo" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.0-1:&nbsp;<a href="geo-1.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -288,7 +288,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="getenv"></a><a href="#getenv" class="pkg"><b>getenv</b></a> - environment variables retrieval module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-getenv.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-getenv" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-getenv.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-getenv" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="getenv-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -297,7 +297,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="halo"></a><a href="#halo" class="pkg"><b>halo</b></a> - Simple OOP Library For Lua<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-halo.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-halo" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-halo.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-halo" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.9-1:&nbsp;<a href="halo-1.1.9-1.rockspec">rockspec</a><br/>1.1.8-1:&nbsp;<a href="halo-1.1.8-1.rockspec">rockspec</a><br/>1.1.7-1:&nbsp;<a href="halo-1.1.7-1.rockspec">rockspec</a><br/>1.1.0-1:&nbsp;<a href="halo-1.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -306,7 +306,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="hex"></a><a href="#hex" class="pkg"><b>hex</b></a> - hexadecimal encode/decode module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-hex.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-hex" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-hex.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-hex" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.2-1:&nbsp;<a href="hex-1.0.2-1.rockspec">rockspec</a><br/>1.0.1-1:&nbsp;<a href="hex-1.0.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -315,7 +315,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="httpcli"></a><a href="#httpcli" class="pkg"><b>httpcli</b></a> - HTTP client module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-httpcli.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-httpcli" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-httpcli.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-httpcli" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.4.1-1:&nbsp;<a href="httpcli-1.4.1-1.rockspec">rockspec</a><br/>1.4.0-1:&nbsp;<a href="httpcli-1.4.0-1.rockspec">rockspec</a><br/>1.3.4-1:&nbsp;<a href="httpcli-1.3.4-1.rockspec">rockspec</a><br/></td></tr>
@@ -324,7 +324,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="httpcli-resty"></a><a href="#httpcli-resty" class="pkg"><b>httpcli-resty</b></a> - HTTP client module for OpenResty<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-httpcli-resty.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-httpcli-resty" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-httpcli-resty.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-httpcli-resty" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.2.2-1:&nbsp;<a href="httpcli-resty-1.2.2-1.rockspec">rockspec</a><br/></td></tr>
@@ -333,7 +333,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="httpconsts"></a><a href="#httpconsts" class="pkg"><b>httpconsts</b></a> - HTTP method names and status code constants module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-httpconsts.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-httpconsts" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-httpconsts.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-httpconsts" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.1-1:&nbsp;<a href="httpconsts-1.0.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -342,7 +342,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="idna"></a><a href="#idna" class="pkg"><b>idna</b></a> - libidn bindings for lua<br/>
 </p><blockquote><p><br/>
 <p><b>External dependencies:</b> idn</p>
-<font size="-1"><a href="git://github.com/mah0x211/lua-idna.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-idna" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-idna.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-idna" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.0-1:&nbsp;<a href="idna-1.0.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -360,7 +360,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="iputil"></a><a href="#iputil" class="pkg"><b>iputil</b></a> - ip address utility<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-iputil.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-iputil" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-iputil.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-iputil" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.1-1:&nbsp;<a href="iputil-1.0.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -369,7 +369,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="isa"></a><a href="#isa" class="pkg"><b>isa</b></a> - type checking utility module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-isa.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-isa" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-isa.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-isa" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="isa-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -378,7 +378,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="jose"></a><a href="#jose" class="pkg"><b>jose</b></a> - JOSE(JSON Object Signing and Encryption) module<br/>
 </p><blockquote><p><br/>
 <p><b>External dependencies:</b> openssl</p>
-<font size="-1"><a href="git://github.com/mah0x211/lua-jose.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-jose" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-jose.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-jose" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="jose-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -387,7 +387,7 @@ scm-1:&nbsp;<a href="fsrouter-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="jsonrpc-parser"></a><a href="#jsonrpc-parser" class="pkg"><b>jsonrpc-parser</b></a> - JSON-RPC 2.0 Message Parser<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-jsonrpc-parser.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-jsonrpc-parser" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-jsonrpc-parser.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-jsonrpc-parser" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="jsonrpc-parser-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -423,7 +423,7 @@ scm-1:&nbsp;<a href="jsonrpc-parser-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="loadchunk"></a><a href="#loadchunk" class="pkg"><b>loadchunk</b></a> - Lua chunk loader module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-loadchunk.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-loadchunk" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-loadchunk.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-loadchunk" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="loadchunk-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -432,7 +432,7 @@ scm-1:&nbsp;<a href="jsonrpc-parser-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="lschema"></a><a href="#lschema" class="pkg"><b>lschema</b></a> - lua data schema module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-lschema.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-lschema" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-lschema.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-lschema" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.6.0-1:&nbsp;<a href="lschema-1.6.0-1.rockspec">rockspec</a><br/>1.5.1-1:&nbsp;<a href="lschema-1.5.1-1.rockspec">rockspec</a><br/>1.5.0-1:&nbsp;<a href="lschema-1.5.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -441,7 +441,7 @@ scm-1:&nbsp;<a href="jsonrpc-parser-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="lua-cjson"></a><a href="#lua-cjson" class="pkg"><b>lua-cjson</b></a> - A fast JSON encoding/parsing module<br/>
 </p><blockquote><p> The Lua CJSON module provides JSON support for Lua. It features: - Fast, standards compliant encoding/parsing routines - Full support for JSON with UTF-8, including decoding surrogate pairs - Optional run-time support for common exceptions to the JSON specification (infinity, NaN,..) - No dependencies on other libraries <br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-cjson.git">latest sources</a> | <a href="http://www.kyne.com.au/~mark/software/lua-cjson.php" target="_blank">project homepage</a> | License: MIT</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-cjson.git">latest sources</a> | <a href="http://www.kyne.com.au/~mark/software/lua-cjson.php" target="_blank">project homepage</a> | License: MIT</font></p>
 </blockquote></a></td>
 <td class="version">
 2.1.0-1:&nbsp;<a href="lua-cjson-2.1.0-1.rockspec">rockspec</a>,&nbsp;<a href="lua-cjson-2.1.0-1.src.rock">src</a><br/></td></tr>
@@ -468,7 +468,7 @@ scm-1:&nbsp;<a href="lzfse-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="mediatypes"></a><a href="#mediatypes" class="pkg"><b>mediatypes</b></a> - MIME type utility module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-mediatypes.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-mediatypes" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-mediatypes.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-mediatypes" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 2.0.0-1:&nbsp;<a href="mediatypes-2.0.0-1.rockspec">rockspec</a><br/>1.0.1-1:&nbsp;<a href="mediatypes-1.0.1-1.rockspec">rockspec</a><br/>1.0.0-1:&nbsp;<a href="mediatypes-1.0.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -477,7 +477,7 @@ scm-1:&nbsp;<a href="lzfse-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="minheap"></a><a href="#minheap" class="pkg"><b>minheap</b></a> - min-heap module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-minheap.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-minheap" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-minheap.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-minheap" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.1-1:&nbsp;<a href="minheap-0.1.1-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="minheap-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -486,7 +486,7 @@ scm-1:&nbsp;<a href="lzfse-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="msgbus"></a><a href="#msgbus" class="pkg"><b>msgbus</b></a> - message-bus module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-msgbus.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-msgbus" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-msgbus.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-msgbus" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="msgbus-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -495,7 +495,7 @@ scm-1:&nbsp;<a href="msgbus-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="net"></a><a href="#net" class="pkg"><b>net</b></a> - net module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-net.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-net" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-net.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-net" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.25.0-1:&nbsp;<a href="net-0.25.0-1.rockspec">rockspec</a><br/>0.23.0-1:&nbsp;<a href="net-0.23.0-1.rockspec">rockspec</a><br/>0.22.1-1:&nbsp;<a href="net-0.22.1-1.rockspec">rockspec</a><br/>0.22.0-1:&nbsp;<a href="net-0.22.0-1.rockspec">rockspec</a><br/>0.21.1-1:&nbsp;<a href="net-0.21.1-1.rockspec">rockspec</a><br/>0.21.0-1:&nbsp;<a href="net-0.21.0-1.rockspec">rockspec</a><br/>0.20.1-1:&nbsp;<a href="net-0.20.1-1.rockspec">rockspec</a><br/>0.20.0-1:&nbsp;<a href="net-0.20.0-1.rockspec">rockspec</a><br/>0.19.1-1:&nbsp;<a href="net-0.19.1-1.rockspec">rockspec</a><br/>0.19.0-1:&nbsp;<a href="net-0.19.0-1.rockspec">rockspec</a><br/>0.18.1-1:&nbsp;<a href="net-0.18.1-1.rockspec">rockspec</a><br/>0.18.0-1:&nbsp;<a href="net-0.18.0-1.rockspec">rockspec</a><br/>0.17.1-1:&nbsp;<a href="net-0.17.1-1.rockspec">rockspec</a><br/>0.17.0-1:&nbsp;<a href="net-0.17.0-1.rockspec">rockspec</a><br/>0.16.0-1:&nbsp;<a href="net-0.16.0-1.rockspec">rockspec</a><br/>0.15.0-1:&nbsp;<a href="net-0.15.0-1.rockspec">rockspec</a><br/>0.14.0-1:&nbsp;<a href="net-0.14.0-1.rockspec">rockspec</a><br/>0.13.0-1:&nbsp;<a href="net-0.13.0-1.rockspec">rockspec</a><br/>0.12.0-1:&nbsp;<a href="net-0.12.0-1.rockspec">rockspec</a><br/>0.11.0-1:&nbsp;<a href="net-0.11.0-1.rockspec">rockspec</a><br/>0.10.1-1:&nbsp;<a href="net-0.10.1-1.rockspec">rockspec</a><br/>0.10.0-1:&nbsp;<a href="net-0.10.0-1.rockspec">rockspec</a><br/>0.9.1-1:&nbsp;<a href="net-0.9.1-1.rockspec">rockspec</a><br/>0.9.0-1:&nbsp;<a href="net-0.9.0-1.rockspec">rockspec</a><br/>0.8.1-1:&nbsp;<a href="net-0.8.1-1.rockspec">rockspec</a><br/>0.8.0-1:&nbsp;<a href="net-0.8.0-1.rockspec">rockspec</a><br/>0.7.0-1:&nbsp;<a href="net-0.7.0-1.rockspec">rockspec</a><br/>0.6.1-1:&nbsp;<a href="net-0.6.1-1.rockspec">rockspec</a><br/>0.6.0-1:&nbsp;<a href="net-0.6.0-1.rockspec">rockspec</a><br/>0.5.2-1:&nbsp;<a href="net-0.5.2-1.rockspec">rockspec</a><br/>0.5.1-1:&nbsp;<a href="net-0.5.1-1.rockspec">rockspec</a><br/>0.5.0-1:&nbsp;<a href="net-0.5.0-1.rockspec">rockspec</a><br/>0.4.1-1:&nbsp;<a href="net-0.4.1-1.rockspec">rockspec</a><br/>0.4.0-1:&nbsp;<a href="net-0.4.0-1.rockspec">rockspec</a><br/>0.3.0-1:&nbsp;<a href="net-0.3.0-1.rockspec">rockspec</a><br/>0.2.0-1:&nbsp;<a href="net-0.2.0-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="net-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -513,7 +513,7 @@ scm-1:&nbsp;<a href="msgbus-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="net-memcached"></a><a href="#net-memcached" class="pkg"><b>net-memcached</b></a> - memcached client module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-net-memcached.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-net-memcached" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-net-memcached.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-net-memcached" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -522,7 +522,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="nosigpipe"></a><a href="#nosigpipe" class="pkg"><b>nosigpipe</b></a> - a module that ignore SIGPIPE<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-nosigpipe.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-nosigpipe" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-nosigpipe.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-nosigpipe" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="nosigpipe-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -531,7 +531,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="notifier"></a><a href="#notifier" class="pkg"><b>notifier</b></a> - event notification module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-notifier.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-notifier" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-notifier.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-notifier" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.3-1:&nbsp;<a href="notifier-1.1.3-1.rockspec">rockspec</a><br/>1.1.2-1:&nbsp;<a href="notifier-1.1.2-1.rockspec">rockspec</a><br/>1.1.1-1:&nbsp;<a href="notifier-1.1.1-1.rockspec">rockspec</a><br/>1.1.0-1:&nbsp;<a href="notifier-1.1.0-1.rockspec">rockspec</a><br/>1.0.0-1:&nbsp;<a href="notifier-1.0.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -540,7 +540,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="ossp-uuid"></a><a href="#ossp-uuid" class="pkg"><b>ossp-uuid</b></a> - OSSP uuid bindings for lua<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-ossp-uuid.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-ossp-uuid" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-ossp-uuid.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-ossp-uuid" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.0-1:&nbsp;<a href="ossp-uuid-1.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -549,7 +549,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="pages"></a><a href="#pages" class="pkg"><b>pages</b></a> - lua template processor<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-pages.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-pages" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-pages.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-pages" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.2-1:&nbsp;<a href="pages-1.0.2-1.rockspec">rockspec</a><br/></td></tr>
@@ -558,7 +558,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="parcel"></a><a href="#parcel" class="pkg"><b>parcel</b></a> - binary serialization module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-parcel.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-parcel" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-parcel.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-parcel" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.1-1:&nbsp;<a href="parcel-0.1.1-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="parcel-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -567,7 +567,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="path"></a><a href="#path" class="pkg"><b>path</b></a> - path string manipulation<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-path.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-path" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-path.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-path" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.0-1:&nbsp;<a href="path-1.1.0-1.rockspec">rockspec</a><br/>1.0.5-1:&nbsp;<a href="path-1.0.5-1.rockspec">rockspec</a><br/>1.0.4-1:&nbsp;<a href="path-1.0.4-1.rockspec">rockspec</a><br/></td></tr>
@@ -603,7 +603,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="reco"></a><a href="#reco" class="pkg"><b>reco</b></a> - reusable coroutine module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-reco.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-reco" target="_blank">project homepage</a> | License: MIT</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-reco.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-reco" target="_blank">project homepage</a> | License: MIT</font></p>
 </blockquote></a></td>
 <td class="version">
 1.4.3-1:&nbsp;<a href="reco-1.4.3-1.rockspec">rockspec</a><br/>1.4.2-1:&nbsp;<a href="reco-1.4.2-1.rockspec">rockspec</a><br/>1.4.1-1:&nbsp;<a href="reco-1.4.1-1.rockspec">rockspec</a><br/>1.4.0-1:&nbsp;<a href="reco-1.4.0-1.rockspec">rockspec</a><br/>1.3.1-1:&nbsp;<a href="reco-1.3.1-1.rockspec">rockspec</a><br/>1.3.0-1:&nbsp;<a href="reco-1.3.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -612,7 +612,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="ref"></a><a href="#ref" class="pkg"><b>ref</b></a> - value reference operation module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-ref.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-ref" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-ref.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-ref" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="ref-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -621,7 +621,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="regex"></a><a href="#regex" class="pkg"><b>regex</b></a> - simple regular expression module for lua<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-regex.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-regex" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-regex.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-regex" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="regex-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -639,7 +639,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="resty-entity"></a><a href="#resty-entity" class="pkg"><b>resty-entity</b></a> - request entity handling module for openresty<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-resty-entity.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-resty-entity" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-resty-entity.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-resty-entity" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.3.4-1:&nbsp;<a href="resty-entity-1.3.4-1.rockspec">rockspec</a><br/>1.3.3-1:&nbsp;<a href="resty-entity-1.3.3-1.rockspec">rockspec</a><br/>1.3.2-1:&nbsp;<a href="resty-entity-1.3.2-1.rockspec">rockspec</a><br/></td></tr>
@@ -648,7 +648,7 @@ scm-1:&nbsp;<a href="net-memcached-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="resty-filelog"></a><a href="#resty-filelog" class="pkg"><b>resty-filelog</b></a> - <br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-resty-filelog.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-resty-filelog" target="_blank">project homepage</a> | License: MIT</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-resty-filelog.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-resty-filelog" target="_blank">project homepage</a> | License: MIT</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -657,7 +657,7 @@ scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="rfcvalid"></a><a href="#rfcvalid" class="pkg"><b>rfcvalid</b></a> - RFC specification based validation modules<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-rfcvalid.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-rfcvalid" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-rfcvalid.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-rfcvalid" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.6.0-1:&nbsp;<a href="rfcvalid-0.6.0-1.rockspec">rockspec</a><br/>0.5.2-1:&nbsp;<a href="rfcvalid-0.5.2-1.rockspec">rockspec</a><br/>0.5.1-1:&nbsp;<a href="rfcvalid-0.5.1-1.rockspec">rockspec</a><br/>0.5.0-1:&nbsp;<a href="rfcvalid-0.5.0-1.rockspec">rockspec</a><br/>0.4.1-1:&nbsp;<a href="rfcvalid-0.4.1-1.rockspec">rockspec</a><br/>0.4.0-1:&nbsp;<a href="rfcvalid-0.4.0-1.rockspec">rockspec</a><br/>0.3.0-1:&nbsp;<a href="rfcvalid-0.3.0-1.rockspec">rockspec</a><br/>0.2.1-1:&nbsp;<a href="rfcvalid-0.2.1-1.rockspec">rockspec</a><br/>0.2.0-1:&nbsp;<a href="rfcvalid-0.2.0-1.rockspec">rockspec</a><br/>0.1.1-1:&nbsp;<a href="rfcvalid-0.1.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -666,7 +666,7 @@ scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="rootdir"></a><a href="#rootdir" class="pkg"><b>rootdir</b></a> - fixed directory access module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-rootdir.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-rootdir" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-rootdir.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-rootdir" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.5-1:&nbsp;<a href="rootdir-1.0.5-1.rockspec">rockspec</a><br/>1.0.4-1:&nbsp;<a href="rootdir-1.0.4-1.rockspec">rockspec</a><br/>1.0.3-1:&nbsp;<a href="rootdir-1.0.3-1.rockspec">rockspec</a><br/>1.0.2-1:&nbsp;<a href="rootdir-1.0.2-1.rockspec">rockspec</a><br/></td></tr>
@@ -684,7 +684,7 @@ scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="session"></a><a href="#session" class="pkg"><b>session</b></a> - session module.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-session.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-session" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-session.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-session" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.2.0-1:&nbsp;<a href="session-1.2.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -702,7 +702,7 @@ scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="siphash"></a><a href="#siphash" class="pkg"><b>siphash</b></a> - siphash module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-siphash.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-siphash" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-siphash.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-siphash" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.1-1:&nbsp;<a href="siphash-1.0.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -711,7 +711,7 @@ scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="string-split"></a><a href="#string-split" class="pkg"><b>string-split</b></a> - split a string into an array of substrings.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-string-split.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-string-split" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-string-split.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-string-split" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.2.0-1:&nbsp;<a href="string-split-0.2.0-1.rockspec">rockspec</a><br/>0.1.1-1:&nbsp;<a href="string-split-0.1.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -720,7 +720,7 @@ scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="string-trim"></a><a href="#string-trim" class="pkg"><b>string-trim</b></a> - strip the space at both ends of string.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-string-trim.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-string-trim" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-string-trim.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-string-trim" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="string-trim-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -738,7 +738,7 @@ scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="table-flatten"></a><a href="#table-flatten" class="pkg"><b>table-flatten</b></a> - flatten a table into a table of specified depth.<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-table-flatten.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-table-flatten" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-table-flatten.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-table-flatten" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.2.0-1:&nbsp;<a href="table-flatten-0.2.0-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="table-flatten-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -747,7 +747,7 @@ scm-1:&nbsp;<a href="resty-filelog-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="thumbnailer"></a><a href="#thumbnailer" class="pkg"><b>thumbnailer</b></a> - thumbnail generator<br/>
 </p><blockquote><p><br/>
 <p><b>External dependencies:</b> imlib2</p>
-<font size="-1"><a href="git://github.com/mah0x211/lua-thumbnailer.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-thumbnailer" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-thumbnailer.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-thumbnailer" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="thumbnailer-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -756,7 +756,7 @@ scm-1:&nbsp;<a href="thumbnailer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="toboolean"></a><a href="#toboolean" class="pkg"><b>toboolean</b></a> - string to boolean conversion module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-toboolean.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-toboolean" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-toboolean.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-toboolean" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="toboolean-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -765,7 +765,7 @@ scm-1:&nbsp;<a href="thumbnailer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="tointeger"></a><a href="#tointeger" class="pkg"><b>tointeger</b></a> - string to integer conversion module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-tointeger.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-tointeger" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-tointeger.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-tointeger" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="tointeger-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -774,7 +774,7 @@ scm-1:&nbsp;<a href="thumbnailer-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="transpiler"></a><a href="#transpiler" class="pkg"><b>transpiler</b></a> - url transpiler<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-transpiler.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-transpiler" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-transpiler.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-transpiler" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 scm-1:&nbsp;<a href="transpiler-scm-1.rockspec">rockspec</a><br/></td></tr>
@@ -783,7 +783,7 @@ scm-1:&nbsp;<a href="transpiler-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="tsukuyomi"></a><a href="#tsukuyomi" class="pkg"><b>tsukuyomi</b></a> - lua simple template engine<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/tsukuyomi.git">latest sources</a> | <a href="https://github.com/mah0x211/tsukuyomi" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/tsukuyomi.git">latest sources</a> | <a href="https://github.com/mah0x211/tsukuyomi" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.1.2-1:&nbsp;<a href="tsukuyomi-1.1.2-1.rockspec">rockspec</a><br/>1.1.1-1:&nbsp;<a href="tsukuyomi-1.1.1-1.rockspec">rockspec</a><br/>1.1.0-1:&nbsp;<a href="tsukuyomi-1.1.0-1.rockspec">rockspec</a><br/>1.0.2-1:&nbsp;<a href="tsukuyomi-1.0.2-1.rockspec">rockspec</a><br/></td></tr>
@@ -819,7 +819,7 @@ scm-1:&nbsp;<a href="usher-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="util"></a><a href="#util" class="pkg"><b>util</b></a> - utility functions<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-util.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-util" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-util.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-util" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.5.1-1:&nbsp;<a href="util-1.5.1-1.rockspec">rockspec</a><br/></td></tr>
@@ -828,7 +828,7 @@ scm-1:&nbsp;<a href="usher-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="vardir"></a><a href="#vardir" class="pkg"><b>vardir</b></a> - <br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-vardir.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-vardir" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-vardir.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-vardir" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.1-1:&nbsp;<a href="vardir-0.1.1-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="vardir-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -846,7 +846,7 @@ scm-1:&nbsp;<a href="vips-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="writelog"></a><a href="#writelog" class="pkg"><b>writelog</b></a> - simple logging module<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-writelog.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-writelog" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-writelog.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-writelog" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.6.0-1:&nbsp;<a href="writelog-0.6.0-1.rockspec">rockspec</a><br/>0.5.1-1:&nbsp;<a href="writelog-0.5.1-1.rockspec">rockspec</a><br/>0.5.0-1:&nbsp;<a href="writelog-0.5.0-1.rockspec">rockspec</a><br/>0.4.0-1:&nbsp;<a href="writelog-0.4.0-1.rockspec">rockspec</a><br/>0.3.0-1:&nbsp;<a href="writelog-0.3.0-1.rockspec">rockspec</a><br/>0.2.0-1:&nbsp;<a href="writelog-0.2.0-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="writelog-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -855,7 +855,7 @@ scm-1:&nbsp;<a href="vips-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="writelog-file"></a><a href="#writelog-file" class="pkg"><b>writelog-file</b></a> - file logger module of writelog<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-writelog-file.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-writelog-file" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-writelog-file.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-writelog-file" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.1.0-1:&nbsp;<a href="writelog-file-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -864,7 +864,7 @@ scm-1:&nbsp;<a href="vips-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="writelog-tcp"></a><a href="#writelog-tcp" class="pkg"><b>writelog-tcp</b></a> - tcp logger module of writelog<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-writelog-tcp.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-writelog-tcp" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-writelog-tcp.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-writelog-tcp" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.2.0-1:&nbsp;<a href="writelog-tcp-0.2.0-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="writelog-tcp-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -873,7 +873,7 @@ scm-1:&nbsp;<a href="vips-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="writelog-udp"></a><a href="#writelog-udp" class="pkg"><b>writelog-udp</b></a> - udp logger module of writelog<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-writelog-udp.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-writelog-udp" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-writelog-udp.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-writelog-udp" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 0.2.0-1:&nbsp;<a href="writelog-udp-0.2.0-1.rockspec">rockspec</a><br/>0.1.0-1:&nbsp;<a href="writelog-udp-0.1.0-1.rockspec">rockspec</a><br/></td></tr>
@@ -882,7 +882,7 @@ scm-1:&nbsp;<a href="vips-scm-1.rockspec">rockspec</a><br/></td></tr>
 <p><a name="xxhash"></a><a href="#xxhash" class="pkg"><b>xxhash</b></a> - xxhash binding<br/>
 </p><blockquote><p><br/>
 
-<font size="-1"><a href="git://github.com/mah0x211/lua-xxhash.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-xxhash" target="_blank">project homepage</a> | License: MIT/X11</font></p>
+<font size="-1"><a href="git+https://github.com/mah0x211/lua-xxhash.git">latest sources</a> | <a href="https://github.com/mah0x211/lua-xxhash" target="_blank">project homepage</a> | License: MIT/X11</font></p>
 </blockquote></a></td>
 <td class="version">
 1.0.0-1:&nbsp;<a href="xxhash-1.0.0-1.rockspec">rockspec</a><br/></td></tr>

--- a/iputil-1.0.1-1.rockspec
+++ b/iputil-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "iputil"
 version = "1.0.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-iputil.git",
+    url = "git+https://github.com/mah0x211/lua-iputil.git",
     tag = "v1.0.1"
 }
 description = {

--- a/isa-0.1.0-1.rockspec
+++ b/isa-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "isa"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-isa.git",
+    url = "git+https://github.com/mah0x211/lua-isa.git",
     tag = "v0.1.0"
 }
 description = {

--- a/jose-0.1.0-1.rockspec
+++ b/jose-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "jose"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-jose.git",
+    url = "git+https://github.com/mah0x211/lua-jose.git",
     tag = "v0.1.0"
 }
 description = {

--- a/jsonrpc-parser-scm-1.rockspec
+++ b/jsonrpc-parser-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "jsonrpc-parser"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-jsonrpc-parser.git"
+    url = "git+https://github.com/mah0x211/lua-jsonrpc-parser.git"
 }
 description = {
     summary = "JSON-RPC 2.0 Message Parser",

--- a/llsocket-0.1.0-1.rockspec
+++ b/llsocket-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "llsocket"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-llsocket.git",
+    url = "git+https://github.com/mah0x211/lua-llsocket.git",
     tag = "v0.1.0"
 }
 description = {

--- a/llsocket-0.1.1-1.rockspec
+++ b/llsocket-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "llsocket"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-llsocket.git",
+    url = "git+https://github.com/mah0x211/lua-llsocket.git",
     tag = "v0.1.1"
 }
 description = {

--- a/llsocket-0.1.2-1.rockspec
+++ b/llsocket-0.1.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "llsocket"
 version = "0.1.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-llsocket.git",
+    url = "git+https://github.com/mah0x211/lua-llsocket.git",
     tag = "v0.1.2"
 }
 description = {

--- a/loadchunk-0.1.0-1.rockspec
+++ b/loadchunk-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "loadchunk"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-loadchunk.git",
+    url = "git+https://github.com/mah0x211/lua-loadchunk.git",
     tag = "v0.1.0"
 }
 description = {

--- a/lschema-1.5.0-1.rockspec
+++ b/lschema-1.5.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "lschema"
 version = "1.5.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-lschema.git",
+    url = "git+https://github.com/mah0x211/lua-lschema.git",
     tag = "v1.5.0"
 }
 description = {

--- a/lschema-1.5.1-1.rockspec
+++ b/lschema-1.5.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "lschema"
 version = "1.5.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-lschema.git",
+    url = "git+https://github.com/mah0x211/lua-lschema.git",
     tag = "v1.5.1"
 }
 description = {

--- a/lschema-1.6.0-1.rockspec
+++ b/lschema-1.6.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "lschema"
 version = "1.6.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-lschema.git",
+    url = "git+https://github.com/mah0x211/lua-lschema.git",
     tag = "v1.6.0"
 }
 description = {

--- a/lua-cjson-2.1.0-1.rockspec
+++ b/lua-cjson-2.1.0-1.rockspec
@@ -2,7 +2,7 @@ package = "lua-cjson"
 version = "2.1.0-1"
 
 source = {
-    url = "git://github.com/mah0x211/lua-cjson.git",
+    url = "git+https://github.com/mah0x211/lua-cjson.git",
     branch = "decode_null_option"
 }
 

--- a/magic-1.0.0-1.rockspec
+++ b/magic-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "magic"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-magic.git",
+    url = "git+https://github.com/mah0x211/lua-magic.git",
     tag = "v1.0.0"
 }
 description = {

--- a/mediatypes-1.0.0-1.rockspec
+++ b/mediatypes-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "mediatypes"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-mediatypes.git",
+    url = "git+https://github.com/mah0x211/lua-mediatypes.git",
     tag = "v1.0.0"
 }
 description = {

--- a/mediatypes-1.0.1-1.rockspec
+++ b/mediatypes-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "mediatypes"
 version = "1.0.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-mediatypes.git",
+    url = "git+https://github.com/mah0x211/lua-mediatypes.git",
     tag = "v1.0.1"
 }
 description = {

--- a/mediatypes-2.0.0-1.rockspec
+++ b/mediatypes-2.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "mediatypes"
 version = "2.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-mediatypes.git",
+    url = "git+https://github.com/mah0x211/lua-mediatypes.git",
     tag = "v2.0.0"
 }
 description = {

--- a/minheap-0.1.0-1.rockspec
+++ b/minheap-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "minheap"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-minheap.git",
+    url = "git+https://github.com/mah0x211/lua-minheap.git",
     tag = "v0.1.0"
 }
 description = {

--- a/minheap-0.1.1-1.rockspec
+++ b/minheap-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "minheap"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-minheap.git",
+    url = "git+https://github.com/mah0x211/lua-minheap.git",
     tag = "v0.1.1"
 }
 description = {

--- a/msgbus-scm-1.rockspec
+++ b/msgbus-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "msgbus"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-msgbus.git"
+    url = "git+https://github.com/mah0x211/lua-msgbus.git"
 }
 description = {
     summary = "message-bus module",

--- a/net-0.1.0-1.rockspec
+++ b/net-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.1.0"
 }
 description = {

--- a/net-0.10.0-1.rockspec
+++ b/net-0.10.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.10.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.10.0"
 }
 description = {

--- a/net-0.10.1-1.rockspec
+++ b/net-0.10.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.10.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.10.1"
 }
 description = {

--- a/net-0.11.0-1.rockspec
+++ b/net-0.11.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.11.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.11.0"
 }
 description = {

--- a/net-0.12.0-1.rockspec
+++ b/net-0.12.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.12.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.12.0"
 }
 description = {

--- a/net-0.13.0-1.rockspec
+++ b/net-0.13.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.13.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.13.0"
 }
 description = {

--- a/net-0.14.0-1.rockspec
+++ b/net-0.14.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.14.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.14.0"
 }
 description = {

--- a/net-0.15.0-1.rockspec
+++ b/net-0.15.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.15.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.15.0"
 }
 description = {

--- a/net-0.16.0-1.rockspec
+++ b/net-0.16.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.16.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.16.0"
 }
 description = {

--- a/net-0.17.0-1.rockspec
+++ b/net-0.17.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.17.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.17.0"
 }
 description = {

--- a/net-0.17.1-1.rockspec
+++ b/net-0.17.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.17.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.17.1"
 }
 description = {

--- a/net-0.18.0-1.rockspec
+++ b/net-0.18.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.18.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.18.0"
 }
 description = {

--- a/net-0.18.1-1.rockspec
+++ b/net-0.18.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.18.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.18.1"
 }
 description = {

--- a/net-0.19.0-1.rockspec
+++ b/net-0.19.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.19.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.19.0"
 }
 description = {

--- a/net-0.19.1-1.rockspec
+++ b/net-0.19.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.19.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.19.1"
 }
 description = {

--- a/net-0.2.0-1.rockspec
+++ b/net-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.2.0"
 }
 description = {

--- a/net-0.20.0-1.rockspec
+++ b/net-0.20.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.20.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.20.0"
 }
 description = {

--- a/net-0.20.1-1.rockspec
+++ b/net-0.20.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.20.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.20.1"
 }
 description = {

--- a/net-0.21.0-1.rockspec
+++ b/net-0.21.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.21.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.21.0"
 }
 description = {

--- a/net-0.21.1-1.rockspec
+++ b/net-0.21.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.21.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.21.1"
 }
 description = {

--- a/net-0.22.0-1.rockspec
+++ b/net-0.22.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.22.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.22.0"
 }
 description = {

--- a/net-0.22.1-1.rockspec
+++ b/net-0.22.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.22.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.22.1"
 }
 description = {

--- a/net-0.23.0-1.rockspec
+++ b/net-0.23.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.23.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.23.0"
 }
 description = {

--- a/net-0.25.0-1.rockspec
+++ b/net-0.25.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.25.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.25.0"
 }
 description = {

--- a/net-0.3.0-1.rockspec
+++ b/net-0.3.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.3.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.3.0"
 }
 description = {

--- a/net-0.4.0-1.rockspec
+++ b/net-0.4.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.4.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.4.0"
 }
 description = {

--- a/net-0.4.1-1.rockspec
+++ b/net-0.4.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.4.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.4.1"
 }
 description = {

--- a/net-0.5.0-1.rockspec
+++ b/net-0.5.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.5.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.5.0"
 }
 description = {

--- a/net-0.5.1-1.rockspec
+++ b/net-0.5.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.5.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.5.1"
 }
 description = {

--- a/net-0.5.2-1.rockspec
+++ b/net-0.5.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.5.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.5.2"
 }
 description = {

--- a/net-0.6.0-1.rockspec
+++ b/net-0.6.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.6.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.6.0"
 }
 description = {

--- a/net-0.6.1-1.rockspec
+++ b/net-0.6.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.6.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.6.1"
 }
 description = {

--- a/net-0.7.0-1.rockspec
+++ b/net-0.7.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.7.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.7.0"
 }
 description = {

--- a/net-0.8.0-1.rockspec
+++ b/net-0.8.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.8.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.8.0"
 }
 description = {

--- a/net-0.8.1-1.rockspec
+++ b/net-0.8.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.8.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.8.1"
 }
 description = {

--- a/net-0.9.0-1.rockspec
+++ b/net-0.9.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.9.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.9.0"
 }
 description = {

--- a/net-0.9.1-1.rockspec
+++ b/net-0.9.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "net"
 version = "0.9.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net.git",
+    url = "git+https://github.com/mah0x211/lua-net.git",
     tag = "v0.9.1"
 }
 description = {

--- a/net-memcached-scm-1.rockspec
+++ b/net-memcached-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "net-memcached"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-net-memcached.git"
+    url = "git+https://github.com/mah0x211/lua-net-memcached.git"
 }
 description = {
     summary = "memcached client module",

--- a/nosigpipe-0.1.0-1.rockspec
+++ b/nosigpipe-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "nosigpipe"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-nosigpipe.git",
+    url = "git+https://github.com/mah0x211/lua-nosigpipe.git",
     tag = "v0.1.0"
 }
 description = {

--- a/notifier-1.0.0-1.rockspec
+++ b/notifier-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "notifier"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-notifier.git",
+    url = "git+https://github.com/mah0x211/lua-notifier.git",
     tag = "v1.0.0"
 }
 description = {

--- a/notifier-1.1.0-1.rockspec
+++ b/notifier-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "notifier"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-notifier.git",
+    url = "git+https://github.com/mah0x211/lua-notifier.git",
     tag = "v1.1.0"
 }
 description = {

--- a/notifier-1.1.1-1.rockspec
+++ b/notifier-1.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "notifier"
 version = "1.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-notifier.git",
+    url = "git+https://github.com/mah0x211/lua-notifier.git",
     tag = "v1.1.1"
 }
 description = {

--- a/notifier-1.1.2-1.rockspec
+++ b/notifier-1.1.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "notifier"
 version = "1.1.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-notifier.git",
+    url = "git+https://github.com/mah0x211/lua-notifier.git",
     tag = "v1.1.2"
 }
 description = {

--- a/notifier-1.1.3-1.rockspec
+++ b/notifier-1.1.3-1.rockspec
@@ -1,7 +1,7 @@
 package = "notifier"
 version = "1.1.3-1"
 source = {
-    url = "git://github.com/mah0x211/lua-notifier.git",
+    url = "git+https://github.com/mah0x211/lua-notifier.git",
     tag = "v1.1.3"
 }
 description = {

--- a/ossp-uuid-1.1.0-1.rockspec
+++ b/ossp-uuid-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "ossp-uuid"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-ossp-uuid.git",
+    url = "git+https://github.com/mah0x211/lua-ossp-uuid.git",
     tag = "v1.1.0"
 }
 description = {

--- a/pages-1.0.2-1.rockspec
+++ b/pages-1.0.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "pages"
 version = "1.0.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-pages.git",
+    url = "git+https://github.com/mah0x211/lua-pages.git",
     tag = "v1.0.2"
 }
 description = {

--- a/parcel-0.1.0-1.rockspec
+++ b/parcel-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "parcel"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-parcel.git",
+    url = "git+https://github.com/mah0x211/lua-parcel.git",
     tag = "v0.1.0"
 }
 description = {

--- a/parcel-0.1.1-1.rockspec
+++ b/parcel-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "parcel"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-parcel.git",
+    url = "git+https://github.com/mah0x211/lua-parcel.git",
     tag = "v0.1.1"
 }
 description = {

--- a/path-1.0.4-1.rockspec
+++ b/path-1.0.4-1.rockspec
@@ -1,7 +1,7 @@
 package = "path"
 version = "1.0.4-1"
 source = {
-    url = "git://github.com/mah0x211/lua-path.git",
+    url = "git+https://github.com/mah0x211/lua-path.git",
     tag = "v1.0.4"
 }
 description = {

--- a/path-1.0.5-1.rockspec
+++ b/path-1.0.5-1.rockspec
@@ -1,7 +1,7 @@
 package = "path"
 version = "1.0.5-1"
 source = {
-    url = "git://github.com/mah0x211/lua-path.git",
+    url = "git+https://github.com/mah0x211/lua-path.git",
     tag = "v1.0.5"
 }
 description = {

--- a/path-1.1.0-1.rockspec
+++ b/path-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "path"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-path.git",
+    url = "git+https://github.com/mah0x211/lua-path.git",
     tag = "v1.1.0"
 }
 description = {

--- a/process-1.4.3-1.rockspec
+++ b/process-1.4.3-1.rockspec
@@ -1,7 +1,7 @@
 package = "process"
 version = "1.4.3-1"
 source = {
-    url = "git://github.com/mah0x211/lua-process.git",
+    url = "git+https://github.com/mah0x211/lua-process.git",
     tag = "v1.4.3"
 }
 description = {

--- a/process-1.5.0-1.rockspec
+++ b/process-1.5.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "process"
 version = "1.5.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-process.git",
+    url = "git+https://github.com/mah0x211/lua-process.git",
     tag = "v1.5.0"
 }
 description = {

--- a/process-1.6.0-1.rockspec
+++ b/process-1.6.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "process"
 version = "1.6.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-process.git",
+    url = "git+https://github.com/mah0x211/lua-process.git",
     tag = "v1.6.0"
 }
 description = {

--- a/process-1.6.1-1.rockspec
+++ b/process-1.6.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "process"
 version = "1.6.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-process.git",
+    url = "git+https://github.com/mah0x211/lua-process.git",
     tag = "v1.6.1"
 }
 description = {

--- a/reco-1.3.0-1.rockspec
+++ b/reco-1.3.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "reco"
 version = "1.3.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-reco.git",
+    url = "git+https://github.com/mah0x211/lua-reco.git",
     tag = "v1.3.0"
 }
 description = {

--- a/reco-1.3.1-1.rockspec
+++ b/reco-1.3.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "reco"
 version = "1.3.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-reco.git",
+    url = "git+https://github.com/mah0x211/lua-reco.git",
     tag = "v1.3.1"
 }
 description = {

--- a/reco-1.4.0-1.rockspec
+++ b/reco-1.4.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "reco"
 version = "1.4.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-reco.git",
+    url = "git+https://github.com/mah0x211/lua-reco.git",
     tag = "v1.4.0"
 }
 description = {

--- a/reco-1.4.1-1.rockspec
+++ b/reco-1.4.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "reco"
 version = "1.4.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-reco.git",
+    url = "git+https://github.com/mah0x211/lua-reco.git",
     tag = "v1.4.1"
 }
 description = {

--- a/reco-1.4.2-1.rockspec
+++ b/reco-1.4.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "reco"
 version = "1.4.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-reco.git",
+    url = "git+https://github.com/mah0x211/lua-reco.git",
     tag = "v1.4.2"
 }
 description = {

--- a/reco-1.4.3-1.rockspec
+++ b/reco-1.4.3-1.rockspec
@@ -1,7 +1,7 @@
 package = "reco"
 version = "1.4.3-1"
 source = {
-    url = "git://github.com/mah0x211/lua-reco.git",
+    url = "git+https://github.com/mah0x211/lua-reco.git",
     tag = "v1.4.3"
 }
 description = {

--- a/ref-0.1.0-1.rockspec
+++ b/ref-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "ref"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-ref.git",
+    url = "git+https://github.com/mah0x211/lua-ref.git",
     tag = "v0.1.0"
 }
 description = {

--- a/regex-0.1.0-1.rockspec
+++ b/regex-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "regex"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-regex.git",
+    url = "git+https://github.com/mah0x211/lua-regex.git",
     tag = "v0.1.0"
 }
 description = {

--- a/resp-0.2.0-1.rockspec
+++ b/resp-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "resp"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resp.git",
+    url = "git+https://github.com/mah0x211/lua-resp.git",
     tag = "v0.2.0"
 }
 description = {

--- a/resp-0.3.0-1.rockspec
+++ b/resp-0.3.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "resp"
 version = "0.3.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resp.git",
+    url = "git+https://github.com/mah0x211/lua-resp.git",
     tag = "v0.3.0"
 }
 description = {

--- a/resp-0.3.1-1.rockspec
+++ b/resp-0.3.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "resp"
 version = "0.3.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resp.git",
+    url = "git+https://github.com/mah0x211/lua-resp.git",
     tag = "v0.3.1"
 }
 description = {

--- a/resp-0.3.2-1.rockspec
+++ b/resp-0.3.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "resp"
 version = "0.3.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resp.git",
+    url = "git+https://github.com/mah0x211/lua-resp.git",
     tag = "v0.3.2"
 }
 description = {

--- a/resp-0.3.3-1.rockspec
+++ b/resp-0.3.3-1.rockspec
@@ -1,7 +1,7 @@
 package = "resp"
 version = "0.3.3-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resp.git",
+    url = "git+https://github.com/mah0x211/lua-resp.git",
     tag = "v0.3.3"
 }
 description = {

--- a/resp-0.4.0-1.rockspec
+++ b/resp-0.4.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "resp"
 version = "0.4.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resp.git",
+    url = "git+https://github.com/mah0x211/lua-resp.git",
     tag = "v0.4.0"
 }
 description = {

--- a/resty-entity-1.3.2-1.rockspec
+++ b/resty-entity-1.3.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "resty-entity"
 version = "1.3.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resty-entity.git",
+    url = "git+https://github.com/mah0x211/lua-resty-entity.git",
     tag = "v1.3.2"
 }
 description = {

--- a/resty-entity-1.3.3-1.rockspec
+++ b/resty-entity-1.3.3-1.rockspec
@@ -1,7 +1,7 @@
 package = "resty-entity"
 version = "1.3.3-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resty-entity.git",
+    url = "git+https://github.com/mah0x211/lua-resty-entity.git",
     tag = "v1.3.3"
 }
 description = {

--- a/resty-entity-1.3.4-1.rockspec
+++ b/resty-entity-1.3.4-1.rockspec
@@ -1,7 +1,7 @@
 package = "resty-entity"
 version = "1.3.4-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resty-entity.git",
+    url = "git+https://github.com/mah0x211/lua-resty-entity.git",
     tag = "v1.3.4"
 }
 description = {

--- a/resty-filelog-scm-1.rockspec
+++ b/resty-filelog-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "resty-filelog"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-resty-filelog.git"
+    url = "git+https://github.com/mah0x211/lua-resty-filelog.git"
 }
 description = {
     summary = "",

--- a/rfcvalid-0.1.1-1.rockspec
+++ b/rfcvalid-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.1.1"
 }
 description = {

--- a/rfcvalid-0.2.0-1.rockspec
+++ b/rfcvalid-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.2.0"
 }
 description = {

--- a/rfcvalid-0.2.1-1.rockspec
+++ b/rfcvalid-0.2.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.2.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.2.1"
 }
 description = {

--- a/rfcvalid-0.3.0-1.rockspec
+++ b/rfcvalid-0.3.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.3.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.3.0"
 }
 description = {

--- a/rfcvalid-0.4.0-1.rockspec
+++ b/rfcvalid-0.4.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.4.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.4.0"
 }
 description = {

--- a/rfcvalid-0.4.1-1.rockspec
+++ b/rfcvalid-0.4.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.4.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.4.1"
 }
 description = {

--- a/rfcvalid-0.5.0-1.rockspec
+++ b/rfcvalid-0.5.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.5.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.5.0"
 }
 description = {

--- a/rfcvalid-0.5.1-1.rockspec
+++ b/rfcvalid-0.5.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.5.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.5.1"
 }
 description = {

--- a/rfcvalid-0.5.2-1.rockspec
+++ b/rfcvalid-0.5.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.5.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.5.2"
 }
 description = {

--- a/rfcvalid-0.6.0-1.rockspec
+++ b/rfcvalid-0.6.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "rfcvalid"
 version = "0.6.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rfcvalid.git",
+    url = "git+https://github.com/mah0x211/lua-rfcvalid.git",
     tag = "v0.6.0"
 }
 description = {

--- a/rootdir-1.0.2-1.rockspec
+++ b/rootdir-1.0.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "rootdir"
 version = "1.0.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rootdir.git",
+    url = "git+https://github.com/mah0x211/lua-rootdir.git",
     tag = "v1.0.2"
 }
 description = {

--- a/rootdir-1.0.3-1.rockspec
+++ b/rootdir-1.0.3-1.rockspec
@@ -1,7 +1,7 @@
 package = "rootdir"
 version = "1.0.3-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rootdir.git",
+    url = "git+https://github.com/mah0x211/lua-rootdir.git",
     tag = "v1.0.3"
 }
 description = {

--- a/rootdir-1.0.4-1.rockspec
+++ b/rootdir-1.0.4-1.rockspec
@@ -1,7 +1,7 @@
 package = "rootdir"
 version = "1.0.4-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rootdir.git",
+    url = "git+https://github.com/mah0x211/lua-rootdir.git",
     tag = "v1.0.4"
 }
 description = {

--- a/rootdir-1.0.5-1.rockspec
+++ b/rootdir-1.0.5-1.rockspec
@@ -1,7 +1,7 @@
 package = "rootdir"
 version = "1.0.5-1"
 source = {
-    url = "git://github.com/mah0x211/lua-rootdir.git",
+    url = "git+https://github.com/mah0x211/lua-rootdir.git",
     tag = "v1.0.5"
 }
 description = {

--- a/sentry-0.1.0-1.rockspec
+++ b/sentry-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.1.0"
 }
 description = {

--- a/sentry-0.1.1-1.rockspec
+++ b/sentry-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.1.1"
 }
 description = {

--- a/sentry-0.1.2-1.rockspec
+++ b/sentry-0.1.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.1.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.1.2"
 }
 description = {

--- a/sentry-0.2.0-1.rockspec
+++ b/sentry-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.2.0"
 }
 description = {

--- a/sentry-0.3.0-1.rockspec
+++ b/sentry-0.3.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.3.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.3.0"
 }
 description = {

--- a/sentry-0.4.0-1.rockspec
+++ b/sentry-0.4.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.4.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.4.0"
 }
 description = {

--- a/sentry-0.4.1-1.rockspec
+++ b/sentry-0.4.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.4.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.4.1"
 }
 description = {

--- a/sentry-0.4.2-1.rockspec
+++ b/sentry-0.4.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.4.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.4.2"
 }
 description = {

--- a/sentry-0.5.0-1.rockspec
+++ b/sentry-0.5.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.5.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.5.0"
 }
 description = {

--- a/sentry-0.6.0-1.rockspec
+++ b/sentry-0.6.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.6.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.6.0"
 }
 description = {

--- a/sentry-0.6.1-1.rockspec
+++ b/sentry-0.6.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "sentry"
 version = "0.6.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-sentry.git",
+    url = "git+https://github.com/mah0x211/lua-sentry.git",
     tag = "v0.6.1"
 }
 description = {

--- a/session-1.2.0-1.rockspec
+++ b/session-1.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "session"
 version = "1.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-session.git",
+    url = "git+https://github.com/mah0x211/lua-session.git",
     tag = "v1.2.0"
 }
 description = {

--- a/signal-1.0.0-1.rockspec
+++ b/signal-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "signal"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-signal.git",
+    url = "git+https://github.com/mah0x211/lua-signal.git",
     tag = "v1.0.0"
 }
 description = {

--- a/signal-1.1.0-1.rockspec
+++ b/signal-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "signal"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-signal.git",
+    url = "git+https://github.com/mah0x211/lua-signal.git",
     tag = "v1.1.0"
 }
 description = {

--- a/siphash-1.0.1-1.rockspec
+++ b/siphash-1.0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "siphash"
 version = "1.0.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-siphash.git",
+    url = "git+https://github.com/mah0x211/lua-siphash.git",
     tag = "v1.0.1"
 }
 description = {

--- a/string-split-0.1.1-1.rockspec
+++ b/string-split-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "string-split"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-string-split.git",
+    url = "git+https://github.com/mah0x211/lua-string-split.git",
     tag = "v0.1.1"
 }
 description = {

--- a/string-split-0.2.0-1.rockspec
+++ b/string-split-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "string-split"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-string-split.git",
+    url = "git+https://github.com/mah0x211/lua-string-split.git",
     tag = "v0.2.0"
 }
 description = {

--- a/string-trim-0.1.0-1.rockspec
+++ b/string-trim-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "string-trim"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-string-trim.git",
+    url = "git+https://github.com/mah0x211/lua-string-trim.git",
     tag = "v0.1.0"
 }
 description = {

--- a/table-flatten-0.1.0-1.rockspec
+++ b/table-flatten-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "table-flatten"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-table-flatten.git",
+    url = "git+https://github.com/mah0x211/lua-table-flatten.git",
     tag = "v0.1.0"
 }
 description = {

--- a/table-flatten-0.2.0-1.rockspec
+++ b/table-flatten-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "table-flatten"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-table-flatten.git",
+    url = "git+https://github.com/mah0x211/lua-table-flatten.git",
     tag = "v0.2.0"
 }
 description = {

--- a/thumbnailer-scm-1.rockspec
+++ b/thumbnailer-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "thumbnailer"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-thumbnailer.git"
+    url = "git+https://github.com/mah0x211/lua-thumbnailer.git"
 }
 description = {
     summary = "thumbnail generator",

--- a/toboolean-0.1.0-1.rockspec
+++ b/toboolean-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "toboolean"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-toboolean.git",
+    url = "git+https://github.com/mah0x211/lua-toboolean.git",
     tag = "v0.1.0"
 }
 description = {

--- a/tointeger-0.1.0-1.rockspec
+++ b/tointeger-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "tointeger"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-tointeger.git",
+    url = "git+https://github.com/mah0x211/lua-tointeger.git",
     tag = "v0.1.0"
 }
 description = {

--- a/transpiler-scm-1.rockspec
+++ b/transpiler-scm-1.rockspec
@@ -1,7 +1,7 @@
 package = "transpiler"
 version = "scm-1"
 source = {
-    url = "git://github.com/mah0x211/lua-transpiler.git"
+    url = "git+https://github.com/mah0x211/lua-transpiler.git"
 }
 description = {
     summary = "url transpiler",

--- a/tsukuyomi-1.0.2-1.rockspec
+++ b/tsukuyomi-1.0.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "tsukuyomi"
 version = "1.0.2-1"
 source = {
-    url = "git://github.com/mah0x211/tsukuyomi.git",
+    url = "git+https://github.com/mah0x211/tsukuyomi.git",
     tag = "v1.0.2"
 }
 description = {

--- a/tsukuyomi-1.1.0-1.rockspec
+++ b/tsukuyomi-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "tsukuyomi"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/tsukuyomi.git",
+    url = "git+https://github.com/mah0x211/tsukuyomi.git",
     tag = "v1.1.0"
 }
 description = {

--- a/tsukuyomi-1.1.1-1.rockspec
+++ b/tsukuyomi-1.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "tsukuyomi"
 version = "1.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/tsukuyomi.git",
+    url = "git+https://github.com/mah0x211/tsukuyomi.git",
     tag = "v1.1.1"
 }
 description = {

--- a/tsukuyomi-1.1.2-1.rockspec
+++ b/tsukuyomi-1.1.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "tsukuyomi"
 version = "1.1.2-1"
 source = {
-    url = "git://github.com/mah0x211/tsukuyomi.git",
+    url = "git+https://github.com/mah0x211/tsukuyomi.git",
     tag = "v1.1.2"
 }
 description = {

--- a/url-1.0.2-1.rockspec
+++ b/url-1.0.2-1.rockspec
@@ -1,7 +1,7 @@
 package = "url"
 version = "1.0.2-1"
 source = {
-    url = "git://github.com/mah0x211/lua-url.git",
+    url = "git+https://github.com/mah0x211/lua-url.git",
     tag = "v1.0.2"
 }
 description = {

--- a/url-1.1.0-1.rockspec
+++ b/url-1.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "url"
 version = "1.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-url.git",
+    url = "git+https://github.com/mah0x211/lua-url.git",
     tag = "v1.1.0"
 }
 description = {

--- a/util-1.5.1-1.rockspec
+++ b/util-1.5.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "util"
 version = "1.5.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-util.git",
+    url = "git+https://github.com/mah0x211/lua-util.git",
     tag = "v1.5.1"
 }
 description = {

--- a/vardir-0.1.0-1.rockspec
+++ b/vardir-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "vardir"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-vardir.git",
+    url = "git+https://github.com/mah0x211/lua-vardir.git",
     tag = "v0.1.0"
 }
 description = {

--- a/vardir-0.1.1-1.rockspec
+++ b/vardir-0.1.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "vardir"
 version = "0.1.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-vardir.git",
+    url = "git+https://github.com/mah0x211/lua-vardir.git",
     tag = "v0.1.1"
 }
 description = {

--- a/writelog-0.1.0-1.rockspec
+++ b/writelog-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog.git",
+    url = "git+https://github.com/mah0x211/lua-writelog.git",
     tag = "v0.1.0"
 }
 description = {

--- a/writelog-0.2.0-1.rockspec
+++ b/writelog-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog.git",
+    url = "git+https://github.com/mah0x211/lua-writelog.git",
     tag = "v0.2.0"
 }
 description = {

--- a/writelog-0.3.0-1.rockspec
+++ b/writelog-0.3.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog"
 version = "0.3.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog.git",
+    url = "git+https://github.com/mah0x211/lua-writelog.git",
     tag = "v0.3.0"
 }
 description = {

--- a/writelog-0.4.0-1.rockspec
+++ b/writelog-0.4.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog"
 version = "0.4.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog.git",
+    url = "git+https://github.com/mah0x211/lua-writelog.git",
     tag = "v0.4.0"
 }
 description = {

--- a/writelog-0.5.0-1.rockspec
+++ b/writelog-0.5.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog"
 version = "0.5.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog.git",
+    url = "git+https://github.com/mah0x211/lua-writelog.git",
     tag = "v0.5.0"
 }
 description = {

--- a/writelog-0.5.1-1.rockspec
+++ b/writelog-0.5.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog"
 version = "0.5.1-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog.git",
+    url = "git+https://github.com/mah0x211/lua-writelog.git",
     tag = "v0.5.1"
 }
 description = {

--- a/writelog-0.6.0-1.rockspec
+++ b/writelog-0.6.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog"
 version = "0.6.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog.git",
+    url = "git+https://github.com/mah0x211/lua-writelog.git",
     tag = "v0.6.0"
 }
 description = {

--- a/writelog-file-0.1.0-1.rockspec
+++ b/writelog-file-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog-file"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog-file.git",
+    url = "git+https://github.com/mah0x211/lua-writelog-file.git",
     tag = "v0.1.0"
 }
 description = {

--- a/writelog-tcp-0.1.0-1.rockspec
+++ b/writelog-tcp-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog-tcp"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog-tcp.git",
+    url = "git+https://github.com/mah0x211/lua-writelog-tcp.git",
     tag = "v0.1.0"
 }
 description = {

--- a/writelog-tcp-0.2.0-1.rockspec
+++ b/writelog-tcp-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog-tcp"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog-tcp.git",
+    url = "git+https://github.com/mah0x211/lua-writelog-tcp.git",
     tag = "v0.2.0"
 }
 description = {

--- a/writelog-udp-0.1.0-1.rockspec
+++ b/writelog-udp-0.1.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog-udp"
 version = "0.1.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog-udp.git",
+    url = "git+https://github.com/mah0x211/lua-writelog-udp.git",
     tag = "v0.1.0"
 }
 description = {

--- a/writelog-udp-0.2.0-1.rockspec
+++ b/writelog-udp-0.2.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "writelog-udp"
 version = "0.2.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-writelog-udp.git",
+    url = "git+https://github.com/mah0x211/lua-writelog-udp.git",
     tag = "v0.2.0"
 }
 description = {

--- a/xxhash-1.0.0-1.rockspec
+++ b/xxhash-1.0.0-1.rockspec
@@ -1,7 +1,7 @@
 package = "xxhash"
 version = "1.0.0-1"
 source = {
-    url = "git://github.com/mah0x211/lua-xxhash.git",
+    url = "git+https://github.com/mah0x211/lua-xxhash.git",
     tag = "v1.0.0"
 }
 description = {


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/
git copies over non https protocols are now deprecated, git+https forces git to clone over https so luarock install still works